### PR TITLE
chore(static): remove .gitignore

### DIFF
--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,4 +1,0 @@
-
-template.data.gouv.fr
-!template.data.gouv.fr/dist/*
-


### PR DESCRIPTION
The `static/.gitignore` seems to do nothing add all the files are in `static/template.data.gouv.fr/dist`.

\to @revolunet > Can you confirm that it's still useful ?

https://github.com/SocialGouv/socialgouv.github.io/blob/05210a922b47cd451a0f9f77443e7b70e3636fe2/static/.gitignore#L1-L4