### PR TITLE
fix(pages): import custom.css in the Layout component

### DIFF
--- a/pages/actus/board-juin-2018.js
+++ b/pages/actus/board-juin-2018.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { Hero, Layout, Section } from "../../src/composants";
 
-import "../../src/custom.css";
-
 const Board1 = () => (
   <Layout>
     <Hero

--- a/pages/actus/saison2.js
+++ b/pages/actus/saison2.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { Hero, Layout, Section } from "../../src/composants";
 
-import "../../src/custom.css";
-
 const title = (
   <div>
     Devenez&nbsp;

--- a/pages/fonctionnement-incubateur.js
+++ b/pages/fonctionnement-incubateur.js
@@ -2,8 +2,6 @@ import React from "react";
 import { Hero, Layout, Section } from "../src/composants";
 import styled from "styled-components";
 
-import "../src/custom.css";
-
 //
 
 const CentralFigure = styled.figure`

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,8 +11,6 @@ import {
   BlocChiffres
 } from "../src/composants";
 
-import "../src/custom.css";
-
 const Homepage = () => (
   <Layout>
     <Head>

--- a/src/composants/Layout.js
+++ b/src/composants/Layout.js
@@ -6,6 +6,8 @@ import { MDXProvider } from "@mdx-js/tag";
 import { ReactPiwik } from "../piwik";
 import { Footer, Header, SvgIcons, GenericLink } from ".";
 
+import "../custom.css";
+
 const components = {
   a: GenericLink
 };


### PR DESCRIPTION
\from @EricH34
Most pages doesn't contain the style chunk when reloaded.
Importing the custom.css file in the Layout component solve most cases as this component is used on most pages (even extended layouts)