### PR TITLE
fix(pages): use _app to share common custom css

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import App from "next/app";
+
+import "../src/custom.css";
+
+export default class MyApp extends App {}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,8 +3,6 @@ import Document, { Head, Main, NextScript } from "next/document";
 import { ServerStyleSheet } from "styled-components";
 import GitHubForkRibbon from "react-github-fork-ribbon";
 
-import "../src/custom.css";
-
 export default class MyDocument extends Document {
   static getInitialProps({ renderPage }) {
     const sheet = new ServerStyleSheet();

--- a/pages/actus/board-juin-2018.js
+++ b/pages/actus/board-juin-2018.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { Hero, Layout, Section } from "../../src/composants";
 
-import "../../src/custom.css";
-
 const Board1 = () => (
   <Layout>
     <Hero

--- a/pages/actus/saison2.js
+++ b/pages/actus/saison2.js
@@ -1,8 +1,6 @@
 import React from "react";
 import { Hero, Layout, Section } from "../../src/composants";
 
-import "../../src/custom.css";
-
 const title = (
   <div>
     Devenez&nbsp;

--- a/pages/fonctionnement-incubateur.js
+++ b/pages/fonctionnement-incubateur.js
@@ -2,8 +2,6 @@ import React from "react";
 import { Hero, Layout, Section } from "../src/composants";
 import styled from "styled-components";
 
-import "../src/custom.css";
-
 //
 
 const CentralFigure = styled.figure`

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,8 +11,6 @@ import {
   BlocChiffres
 } from "../src/composants";
 
-import "../src/custom.css";
-
 const Homepage = () => (
   <Layout>
     <Head>


### PR DESCRIPTION

<img src=https://user-images.githubusercontent.com/730511/47555241-999ef800-d90b-11e8-94ab-529c4caa5b7a.gif width=693>

---

\from @EricH34
Most pages doesn't contain the style chunk when reloaded.
Importing the custom.css file in the pages/_app.js component solve all cases as all pages are wrapped by it.

Closes #92
