### PR TITLE
feat: show Github Stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
       script:
         - NODE_ENV=production yarn build
         - yarn rss
+        - yarn github-stats
         - touch out/.nojekyll
       before_deploy:
         - git config user.name "Social Groovy Bot"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "astech.social.gouv.fr",
+  "name": "incubateur.social.gouv.fr",
   "version": "1.0.1",
   "license": "Apache-2.0",
   "repository": {
@@ -15,7 +15,8 @@
     "dev": "next dev",
     "build": "next build && next export",
     "lint": "eslint src pages",
-    "rss": "node ./scripts/rss.js > ./out/feed.xml"
+    "rss": "node ./scripts/rss.js > ./out/feed.xml",
+    "github-stats": "node ./scripts/github-stats.js > ./out/static/github-stats.json"
   },
   "devDependencies": {
     "@mdx-js/loader": "^0.17.3",
@@ -32,6 +33,7 @@
     "remark-autolink-headings": "^5.1.0"
   },
   "dependencies": {
+    "github-base": "^1.0.0",
     "react": "^16.8.2",
     "react-accessible-accordion": "^2.4.5",
     "react-countup": "^4.1.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,6 @@
 import React from "react";
+import PropTypes from "prop-types";
+
 import Link from "next/link";
 import Head from "next/head";
 
@@ -185,5 +187,9 @@ class Homepage extends React.Component {
     );
   }
 }
+
+Homepage.propTypes = {
+  githubStats: PropTypes.array.isRequired
+};
 
 export default Homepage;

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,94 +11,179 @@ import {
   BlocChiffres
 } from "../src/composants";
 
-const Homepage = () => (
-  <Layout>
-    <Head>
-      <title>Incubateur des ministères sociaux</title>
-    </Head>
-    <Hero
-      title="Bienvenue à l'incubateur des ministères sociaux"
-      tagline="incubateur.social.gouv.fr"
-    />
-    <Section
-      className="section-white"
-      title=""
-      subTitle=""
-      style={{ padding: "1em 0" }}
-    >
-      <BlocChiffres />
-    </Section>
-    <Section title="Notre actualité" subTitle="">
-      <AllActus.all />
-    </Section>
-    <p align="center">
-      {" "}
-      <a href="/actus"> Voir toutes actus</a>
-    </p>
-    <Section
-      title="L'incubateur des ministères sociaux, qu'est-ce donc ?"
-      subTitle=""
-      className="section-color"
-    >
-      <div className="container">
-        <br />
-        C&apos;est à la fois un lieu, une démarche et un ensemble de personnes !
-        <br />
-        <br />
-        L&apos;incubateur des ministères sociaux reprend la démarche et les
-        grands principes de{" "}
-        <a href="http://beta.gouv.fr" target="_blank" rel="noopener noreferrer">
-          beta.gouv
-        </a>
-        , à savoir :<br />
-        <ul>
-          <li>
-            Un leitmotiv : la résolution d&apos;irritants dont vous êtes témoin
-          </li>
-          <li>
-            Des produits fabriqués par des agents{" "}
-            <a href="/actus/saison2"> &quot;intrapreneurs&quot;</a>{" "}
-          </li>
-          <li>
-            Un plateau qui rassemble les développeurs, les coachs, les
-            intrapreneurs et bien d&apos;autres ;)
-          </li>
-          <li>
-            De la co - construction, des petits pas et des produits utilisables
-            très rapidement
-          </li>
-        </ul>
-        L&apos;incubateur offre ainsi l&apos;opportunité de tester de nouveaux
-        modes de conception de services, plus simples, plus agiles et en
-        proximité avec les usagers !<br />
-        <br />
-        <br />
-        <br />
-        <Link href="/fonctionnement-incubateur">
-          {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <a>
-            <center>
-              <img
-                src="../static/images/schema%20inc%201%20v1.png"
-                alt="Illustration fonctionnement IMS"
-                width="600"
-                height="286"
-                style={{
-                  margin: " 0 auto",
-                  borderRadius: "50px"
-                }}
-              />
-              <br />
-              En savoir plus
-            </center>
-          </a>
-        </Link>{" "}
-      </div>
-    </Section>
+// 15/02/2019
+const defaultGithubStats = [
+  {
+    title: "Projets open-source",
+    value: 36
+  },
+  {
+    title: "Tickets",
+    value: 171
+  },
+  {
+    title: "Commits",
+    value: 4135
+  },
+  {
+    title: "Contributeurs",
+    value: 27
+  }
+];
 
-    <div id="produits" />
-    <SectionCards className="section-color" title="Découvrez nos startups" />
-  </Layout>
-);
+const chiffres = [
+  {
+    title: "Startups incubées",
+    value: 5
+  },
+  {
+    title: "Intrapreneurs",
+    value: 8
+  },
+  {
+    title: "m² d&apos;espace dédié",
+    value: 150
+  },
+  {
+    title: "Startups en création",
+    value: 2
+  }
+];
+
+class Homepage extends React.Component {
+  static async getInitialProps() {
+    if (typeof document !== "undefined") {
+      const githubStats = await fetch(
+        document.location.origin + "/static/github-stats.json"
+      ).then(res => res.json());
+      return {
+        githubStats: [
+          {
+            title: "Projets open-source",
+            value: githubStats.count
+          },
+          {
+            title: "Tickets",
+            value: githubStats.issues
+          },
+          {
+            title: "Commits",
+            value: githubStats.commits
+          },
+          {
+            title: "Contributeurs",
+            value: githubStats.contributors
+          }
+        ]
+      };
+    }
+    return { githubStats: defaultGithubStats };
+  }
+  render() {
+    const { githubStats } = this.props;
+    return (
+      <Layout>
+        <Head>
+          <title>Incubateur des ministères sociaux</title>
+        </Head>
+        <Hero
+          title="Bienvenue à l'incubateur des ministères sociaux"
+          tagline="incubateur.social.gouv.fr"
+        />
+        <Section
+          className="section-white"
+          title=""
+          subTitle=""
+          style={{ padding: "1em 0" }}
+        >
+          <BlocChiffres chiffres={chiffres} />
+        </Section>
+        <Section title="Notre actualité" subTitle="">
+          <br />
+          <br />
+          <BlocChiffres chiffres={githubStats} />
+          <br />
+          <br />
+          <AllActus.all />
+        </Section>
+        <p align="center">
+          <a href="/actus"> Voir toutes actus</a>
+        </p>
+        <Section
+          title="L'incubateur des ministères sociaux, qu'est-ce donc ?"
+          subTitle=""
+          className="section-color"
+        >
+          <div className="container">
+            <br />
+            C&apos;est à la fois un lieu, une démarche et un ensemble de
+            personnes !
+            <br />
+            <br />
+            L&apos;incubateur des ministères sociaux reprend la démarche et les
+            grands principes de{" "}
+            <a
+              href="http://beta.gouv.fr"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              beta.gouv
+            </a>
+            , à savoir :<br />
+            <ul>
+              <li>
+                Un leitmotiv : la résolution d&apos;irritants dont vous êtes
+                témoin
+              </li>
+              <li>
+                Des produits fabriqués par des agents{" "}
+                <a href="/actus/saison2"> &quot;intrapreneurs&quot;</a>{" "}
+              </li>
+              <li>
+                Un plateau qui rassemble les développeurs, les coachs, les
+                intrapreneurs et bien d&apos;autres ;)
+              </li>
+              <li>
+                De la co - construction, des petits pas et des produits
+                utilisables très rapidement
+              </li>
+            </ul>
+            L&apos;incubateur offre ainsi l&apos;opportunité de tester de
+            nouveaux modes de conception de services, plus simples, plus agiles
+            et en proximité avec les usagers !<br />
+            <br />
+            <br />
+            <br />
+            <Link href="/fonctionnement-incubateur">
+              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+              <a>
+                <center>
+                  <img
+                    src="../static/images/schema%20inc%201%20v1.png"
+                    alt="Illustration fonctionnement IMS"
+                    width="600"
+                    height="286"
+                    style={{
+                      margin: " 0 auto",
+                      borderRadius: "50px"
+                    }}
+                  />
+                  <br />
+                  En savoir plus
+                </center>
+              </a>
+            </Link>{" "}
+          </div>
+        </Section>
+
+        <div id="produits" />
+        <SectionCards
+          className="section-color"
+          title="Découvrez nos startups"
+        />
+      </Layout>
+    );
+  }
+}
 
 export default Homepage;

--- a/scripts/github-stats.js
+++ b/scripts/github-stats.js
@@ -1,0 +1,66 @@
+const GitHub = require("github-base");
+
+const github = new GitHub({
+  token: process.env.GITHUB_TOKEN
+});
+
+const sum = arr => arr.reduce((sum, i) => sum + i, 0);
+
+const getRepoActivity = repo =>
+  github
+    .get(`/repos/${repo}/stats/contributors`)
+    .then(res => res.body)
+    .catch(console.error);
+
+const getRepos = org =>
+  github
+    .get(`/orgs/${org}/repos`)
+    .then(res => res.body)
+    .catch(console.error);
+
+const getRepoStats = repo =>
+  getRepoActivity(repo).then(
+    activity =>
+      activity &&
+      activity.map && {
+        commits: sum(activity.map(a => a.total)) || 0,
+        contributors: activity.map(a => a.author.login)
+      }
+  );
+
+const isRepoVisible = repo =>
+  !repo.fork && !repo.private && repo.name !== "next-routes";
+
+const flatten = arr =>
+  arr.filter(Boolean).reduce((memo, c) => [...memo, ...c], []);
+const uniquify = arr => [...new Set(arr)];
+
+const isValidContributor = name =>
+  name && !["renovate[bot]", "renovate-bot"].includes(name);
+
+const parseRepos = async repos => {
+  const validRepos = (repos && repos.filter(isRepoVisible)) || [];
+  const reposStats = await Promise.all(
+    validRepos.map(repo => getRepoStats(`${repo.owner.login}/${repo.name}`))
+  );
+
+  const contributors = uniquify(
+    flatten(reposStats.map(repo => repo.contributors))
+  ).filter(isValidContributor).length;
+
+  return {
+    count: validRepos.length,
+    issues: sum(validRepos.map(repo => repo.open_issues)),
+    size: sum(validRepos.map(repo => repo.size)),
+    commits: sum(reposStats.map(repo => repo.commits)),
+    contributors
+  };
+};
+
+const getOrgData = org => getRepos(org).then(parseRepos);
+
+if (require.main === module) {
+  getOrgData("SocialGouv")
+    .then(data => console.log(JSON.stringify(data, null, 2)))
+    .catch(console.log);
+}

--- a/src/composants/BlocChiffres.js
+++ b/src/composants/BlocChiffres.js
@@ -49,4 +49,8 @@ const BlocChiffres = ({ chiffres }) => (
   </div>
 );
 
+BlocChiffres.propTypes = {
+  chiffres: PropTypes.array.isRequired
+};
+
 export default BlocChiffres;

--- a/src/composants/BlocChiffres.js
+++ b/src/composants/BlocChiffres.js
@@ -43,7 +43,10 @@ const BlocChiffres = ({ chiffres }) => (
         <div className="num">
           <ZeroCounter end={chiffre.value} />
         </div>
-        <div className="texte">{chiffre.title}</div>
+        <div
+          className="texte"
+          dangerouslySetInnerHTML={{ __html: chiffre.title }}
+        />
       </BlocChiffre>
     ))}
   </div>

--- a/src/composants/BlocChiffres.js
+++ b/src/composants/BlocChiffres.js
@@ -36,35 +36,16 @@ ZeroCounter.propTypes = {
   end: PropTypes.number
 };
 
-const BlocChiffres = () => (
+const BlocChiffres = ({ chiffres }) => (
   <div style={{ width: "100%", margin: "0 auto" }}>
-    <BlocChiffre>
-      <div className="num">
-        <ZeroCounter end={5} />
-      </div>
-      <div className="texte">Startups incubées</div>
-    </BlocChiffre>
-
-    <BlocChiffre>
-      <div className="num">
-        <ZeroCounter end={8} />
-      </div>
-      <div className="texte">Intrapreneurs</div>
-    </BlocChiffre>
-
-    <BlocChiffre>
-      <div className="num">
-        <ZeroCounter end={150} duration={1.75} />
-      </div>
-      <div className="texte">m² d&apos;espace dédié</div>
-    </BlocChiffre>
-
-    <BlocChiffre>
-      <div className="num">
-        <ZeroCounter end={2} />
-      </div>
-      <div className="texte">Startups en création</div>
-    </BlocChiffre>
+    {chiffres.map(chiffre => (
+      <BlocChiffre key={chiffre.title}>
+        <div className="num">
+          <ZeroCounter end={chiffre.value} />
+        </div>
+        <div className="texte">{chiffre.title}</div>
+      </BlocChiffre>
+    ))}
   </div>
 );
 

--- a/static/github-stats.json
+++ b/static/github-stats.json
@@ -1,0 +1,7 @@
+{
+  "count": 35,
+  "issues": 170,
+  "size": 238454,
+  "commits": 3921,
+  "contributors": 27
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,6 +2994,25 @@ get-value@^2.0.3, get-value@^2.0.6:
   resolved "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
 
+get-value@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-3.0.1.tgz#5efd2a157f1d6a516d7524e124ac52d0a39ef5a8"
+  integrity sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==
+  dependencies:
+    isobject "^3.0.1"
+
+github-base@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/github-base/-/github-base-1.0.0.tgz#346708527a192932c93878d9a45b765a1018d3e0"
+  integrity sha512-5A9OOCQWK80v+bjVRzdK0M/5UtERN9vx9TkJMlkiJA24wu/+lrQLsq5MPQIrSONrSWwt83eAPtBcuQOc2FyK8A==
+  dependencies:
+    get-value "^3.0.1"
+    needle "^2.2.2"
+    paged-request "^1.0.2"
+    parse-link-header "^1.0.1"
+    qs "^6.5.1"
+    use "^3.1.0"
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -4141,7 +4160,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
+needle@^2.1.1, needle@^2.2.1, needle@^2.2.2:
   version "2.2.4"
   resolved "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
   integrity sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==
@@ -4515,6 +4534,13 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
   integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
 
+paged-request@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/paged-request/-/paged-request-1.0.2.tgz#c55479e4482cd02495b84bd53b59a4059579ecae"
+  integrity sha512-2NXKpT0pWoVo31LQhGOfsqD8wViifq6Ml28H8WrqY0GbMvltvpDPx1YZ6jMeVXNbywjECdEhmC2/uFFS1MdMFQ==
+  dependencies:
+    needle "^2.1.1"
+
 pako@~1.0.5:
   version "1.0.6"
   resolved "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
@@ -4580,6 +4606,13 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse-link-header@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-1.0.1.tgz#bedfe0d2118aeb84be75e7b025419ec8a61140a7"
+  integrity sha1-vt/g0hGK64S+deewJUGeyKYRQKc=
+  dependencies:
+    xtend "~4.0.1"
 
 pascal-case@^2.0.0:
   version "2.0.1"
@@ -4956,6 +4989,11 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+qs@^6.5.1:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
+  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
Récupère les stats de nos repos sur GitHub et les affiche sur la home - A améliorer graphiquement

Dans travis, `npm run github-stats` génère un fichier JSON qui peut être mis à jour régulièrement

<img width="908" alt="capture d ecran 2019-02-18 a 12 43 51" src="https://user-images.githubusercontent.com/124937/52948913-1ce0cf80-337b-11e9-982c-a14b733bcc8f.png">
